### PR TITLE
Add web layer component and GitHub Action for deployment automation

### DIFF
--- a/.github/workflows/tfdeploy.yml
+++ b/.github/workflows/tfdeploy.yml
@@ -1,0 +1,35 @@
+name: Deploy Infrastructure
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  terraform:
+    name: "Terraform"
+    runs on: ubuntu-latest
+    env:
+      ARM_CLIENT_ID: ${{ secrets.AZURE_AD_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
+      TF_VAR_env_name: prod
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: "Terraform init"
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_subcommand: "init"
+          tf_actions_working_dir: "./infra"
+          tf_actions_version: 1.3.7
+
+      - name: "Terraform apply"
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_subcommand: "apply"
+          tf_actions_working_dir: "./infra"
+          tf_actions_version: 1.3.7

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,3 @@
+output "dnsdelegation" {
+  value = azurerm_dns_zone.gwa_dnszone.name_servers
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -27,3 +27,9 @@ variable "env_name" {
   type        = string
   default     = "dev"
 }
+
+variable "website_hostname" {
+  description = "Default website hostname"
+  type        = string
+  default     = "gwa-mccrackenyyc.nexxai.dev"
+}

--- a/infra/web.tf
+++ b/infra/web.tf
@@ -1,0 +1,36 @@
+resource "azurerm_resource_group" "gwa_web_rg" {
+  for_each = local.regions
+  name     = "gwa-web-rg-${each.key}-${var.env_name}"
+  location = each.value.longform
+
+  tags = {
+    tag = var.exampletag
+  }
+}
+
+resource "azurerm_service_plan" "gwa_service_plan" {
+  for_each            = local.regions
+  name                = "gwa-service-plan-${each.key}-${var.env_name}"
+  resource_group_name = azurerm_resource_group.gwa_web_rg[each.key].name
+  location            = azurerm_resource_group.gwa_web_rg[each.key].location
+  os_type             = "Linux"
+  sku_name            = "P1v2"
+
+  tags = {
+    tag = var.exampletag
+  }
+}
+
+resource "azurerm_linux_web_app" "gwa_linux_web_app" {
+  for_each            = local.regions
+  name                = "gwa-linux-web-app-${each.key}-${var.env_name}"
+  resource_group_name = azurerm_resource_group.gwa_web_rg[each.key].name
+  location            = azurerm_service_plan.gwa_service_plan[each.key].location
+  service_plan_id     = azurerm_service_plan.gwa_service_plan[each.key].id
+
+  site_config {}
+
+  tags = {
+    tag = var.exampletag
+  }
+}

--- a/infra/web.tf
+++ b/infra/web.tf
@@ -34,3 +34,34 @@ resource "azurerm_linux_web_app" "gwa_linux_web_app" {
     tag = var.exampletag
   }
 }
+
+resource "azurerm_app_service_custom_hostname_binding" "gwa_hostname_binding" {
+  for_each            = local.regions
+  hostname            = var.website_hostname
+  app_service_name    = azurerm_linux_web_app.gwa_linux_web_app[each.key].name
+  resource_group_name = azurerm_resource_group.gwa_web_rg[each.key].name
+
+  depends_on = [
+    azurerm_dns_txt_record.gwa_dnsverifytxtrecord
+  ]
+}
+
+resource "azurerm_dns_txt_record" "gwa_dnsverifytxtrecord" {
+  name                = "asuid"
+  zone_name           = azurerm_dns_zone.gwa_dnszone.name
+  resource_group_name = azurerm_resource_group.gwa_web_rg[element(keys(local.regions), 0)].name
+  ttl                 = 300
+
+  record {
+    value = azurerm_linux_web_app.gwa_linux_web_app[element(keys(local.regions), 0)].custom_domain_verification_id
+  }
+}
+
+resource "azurerm_dns_zone" "gwa_dnszone" {
+  name                = var.website_hostname
+  resource_group_name = azurerm_resource_group.gwa_web_rg[element(keys(local.regions), 0)].name
+
+  tags = {
+    tag = var.exampletag
+  }
+}


### PR DESCRIPTION
TL;DR: Adds completed web layer to project build along with basic pipeline automation

-----

tfdeploy.yml
- service principal
- updates "env_name" variable to prod on push to main
- executes runner with init and apply
- no pre-testing available, please review that action ran successfully after push, if not then notify me for fix

outputs.tf
- added required output for dns information

variables.tf
- added hostname variable for web hosting

web.tf
- full build on web app layer
- includes geo-redundancy
- built using for_each loops to enable rapid scaling in the future
- test by (post deploy) navigating to: https://gwa-linux-web-app-eus2-dev.azurewebsites.net
- full access to be completed in CDN layer next