### PR TITLE
Add secure SQL credentials

### DIFF
--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "2.34.1"
+  constraints = "2.34.1"
+  hashes = [
+    "h1:AUi5LySSJ07YEf3GuAZBSfQ+OVXTFHKEqKqSOOf3u+Q=",
+    "zh:1c117e63562bffe42ed5ae8f2c51c2c54f298b2df32a10c0a8c651c95557962f",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:32418ea3675011c6eec02cda1844fdaa175d449e916b9a3e4931cc156f9947c2",
+    "zh:75795d8381e1332d6011a87939cab240be79319ba3a0c0373554a6cf83045e8b",
+    "zh:aeb2be299bbacc6be935205b6351aaa689a0cbccbf2272cbe37796776f7efdd7",
+    "zh:b3a6424d1bc9cc5d3872626761b0fd246d99cd988f5a0843a87ec571cbcdaefa",
+    "zh:c4471f39c2098f2eaeaaeb7d6411ad0553d1bb250ac7f21189303af3a165718e",
+    "zh:ce5ef6b67c64321f9f60a374accf13df6606f0a716b55d81980b25bd173b912d",
+    "zh:ebf4f4398c8e4dbef1e421ee6d8cbfe59ab88460926770c34fdca6483a8f3891",
+    "zh:f6bd021dbed979f9c41ec3a06c4ffab85dca0972a4f59f365c3c30ef8fe7c222",
+    "zh:fc9e85e8aed5d9e2307c38e6c617b0b227e8009a2314779b18f8bd376bb49549",
+    "zh:fdc99b9d7dfae4c1a7869fa6de91478afdb477d95a9f87325003e985dd19de23",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.40.0"
   constraints = "3.40.0"

--- a/infra/data.tf
+++ b/infra/data.tf
@@ -1,0 +1,3 @@
+data "azuread_user" "admin" {
+  user_principal_name = var.admin_upn
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "=3.40.0"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "=2.34.1"
+    }
   }
 }
 
@@ -19,4 +23,8 @@ provider "azurerm" {
   subscription_id = var.subscription_id
 
   features {}
+}
+
+provider "azuread" {
+  tenant_id = var.tenant_id
 }

--- a/infra/persistence.tf
+++ b/infra/persistence.tf
@@ -22,14 +22,16 @@ resource "azurerm_storage_account" "gwa_sql_logs" {
 }
 
 resource "azurerm_mssql_server" "gwa_sql_server" {
-  for_each                     = local.regions
-  name                         = "gwa-sql-server-${each.key}-${var.env_name}"
-  resource_group_name          = azurerm_resource_group.gwa_sql_rg[each.key].name
-  location                     = azurerm_resource_group.gwa_sql_rg[each.key].location
-  version                      = "12.0"
-  administrator_login          = "missadministrator"
-  administrator_login_password = "thisIsKat11"
-  #creds left in plain text temporarily, to be updated on production deploy
+  for_each            = local.regions
+  name                = "gwa-sql-server-${each.key}-${var.env_name}"
+  resource_group_name = azurerm_resource_group.gwa_sql_rg[each.key].name
+  location            = azurerm_resource_group.gwa_sql_rg[each.key].location
+  version             = "12.0"
+  azuread_administrator {
+    azuread_authentication_only = true
+    login_username              = var.admin_upn
+    object_id                   = data.azuread_user.admin.object_id
+  }
   minimum_tls_version = "1.2"
 
   tags = {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -4,6 +4,11 @@ variable "subscription_id" {
   default     = "20c17ce1-c880-4374-ab18-0c3a72158cf7"
 }
 
+variable "tenant_id" {
+  description = "Azure tenant ID"
+  type        = string
+  default     = "b920523f-f894-4add-a94b-1b0e0eee84ab"
+}
 variable "appname" {
   description = "Product name"
   type        = string
@@ -32,4 +37,10 @@ variable "website_hostname" {
   description = "Default website hostname"
   type        = string
   default     = "gwa-mccrackenyyc.nexxai.dev"
+}
+
+variable "admin_upn" {
+  description = "Azure AD Admin user principal name"
+  type        = string
+  default     = "smccracken_live.ca#EXT#@smccrackenlive.onmicrosoft.com"
 }


### PR DESCRIPTION
Removed temporary plain text credentials to SQL server, updated to hide sensitive information and leverage AzureAD

-----

- added data block to manage AAD data
- added AzureAD as a provider
- plain text creds removed, added AAD-based authentication
- added required variables to enable changes above