### PR TITLE
Updated secondary location

### DIFF
--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -1,6 +1,6 @@
 locals {
   regions = {
     "cc"   = { "longform" = "Canada Central" }
-    "eus2" = { "longform" = "East US 2" }
+    "ce" = { "longform" = "Canada East" }
   }
 }


### PR DESCRIPTION
Issues with TF locating storage accounts in EUS2 when using GitHub runner. Changed locals to use Canada East as a secondary instead.